### PR TITLE
Specify CPU with AVX support for installation

### DIFF
--- a/versioned_docs/version-4.X/getting-started/install/index.mdx
+++ b/versioned_docs/version-4.X/getting-started/install/index.mdx
@@ -25,6 +25,8 @@ Don't want to manage your own Fix Inventory installation? Get started for free w
 
 - At least 2 CPU cores and 8 GB of RAM
 
+- A CPU with AVX support. If running on a VM, set the CPU type to "host" or ensure you expose AVX/AVX2
+
   :::note
 
   Fix Inventory performs CPU-intensive graph operations. In a production setup, we recommend at least four cores and 16 gigabytes of RAM. See [Configuring Fix Inventory Worker](../../reference/configuration/worker.mdx#multi-core-machines) for more information.


### PR DESCRIPTION
Added requirement for CPU with AVX support for installation.

# Description

Minor docs change - graphdb-upgrade will fail with a core dump and no other clues if AVX is not available, note this in setup docs.

By submitting this pull request, I agree to follow the [code of conduct](https://fix.security/code-of-conduct).
